### PR TITLE
Shell::Command Windows fixes and testing/documentation updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.precomp

--- a/META.info
+++ b/META.info
@@ -9,7 +9,8 @@
         "Test"
     ],
     "depends" : [
-        "File::Find"
+        "File::Find",
+        "File::Which"
     ],
     "provides" : {
         "Shell::Command" : "lib/Shell/Command.pm"

--- a/README
+++ b/README
@@ -1,3 +1,0 @@
-This Perl 6 distribution contains the following modules:
-
-Shell::Command

--- a/README.md
+++ b/README.md
@@ -1,0 +1,57 @@
+# Shell::Command
+
+Provides cross-platform routines emulating common \*NIX shell commands
+
+## Build Status
+
+| Operating System  |   Build Status  | CI Provider |
+| ----------------- | --------------- | ----------- |
+| Linux / Mac OS X  | [![Build Status](https://travis-ci.org/tadzik/Shell-Command.svg?branch=master)](https://travis-ci.org/tadzik/Shell-Command)  | Travis CI |
+| Windows 7 64-bit  | [![Build status](https://ci.appveyor.com/api/projects/status/github/tadzik/Shell-Command?svg=true)](https://ci.appveyor.com/project/tadzik/Shell-Command/branch/master)  | AppVeyor |
+
+## Example
+
+```Perl6
+use v6;
+use Shell::Command;
+
+# Recursive folder copy
+cp 't/dir1', 't/dir2', :r;
+
+# Remove directory
+rmdir 't/dupa/foo/bar';
+
+# Make path
+mkpath 't/dir2';
+
+# Remove path
+rm_rf 't/dir2';
+
+# Find perl6 in executable path
+my $perl6_path = which('perl6');
+```
+## See Also
+- [Shell::Command](https://metacpan.org/pod/Shell::Command)
+
+## Author
+
+- Tadeusz “tadzik” Sośnierz"
+
+## Contributors
+- Dagur Valberg Johansson
+- Elizabeth Mattijsen
+- Filip Sergot
+- Geoffrey Broadwell
+- GlitchMr
+- Heather
+- Kamil Kułaga
+- Moritz Lenz
+- Steve Mynott
+- timo
+- Tobias Leich
+- Tim Smith
+- Ahmad M. Zawawi (azawawi @ #perl6)
+
+## LICENSE
+
+MIT License

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,21 @@
+os: Visual Studio 2015
+
+platform: x64
+
+install:
+  - '"C:\Program Files\Microsoft SDKs\Windows\v7.1\Bin\SetEnv.cmd" /x64'
+  - choco install strawberryperl
+  - SET PATH=C:\strawberry\c\bin;C:\strawberry\perl\site\bin;C:\strawberry\perl\bin;%PATH%
+  - git clone https://github.com/tadzik/rakudobrew %USERPROFILE%\rakudobrew
+  - SET PATH=%USERPROFILE%\rakudobrew\bin;%PATH%
+  - rakudobrew build moar
+  - rakudobrew build panda
+  - cd %APPVEYOR_BUILD_FOLDER%
+  - panda installdeps .
+
+build: off
+
+test_script:
+  - prove -v -e "perl6 -Ilib" t/
+
+shallow_clone: true

--- a/lib/Shell/Command.pm
+++ b/lib/Shell/Command.pm
@@ -1,4 +1,7 @@
+use v6;
+
 unit module Shell::Command;
+
 use File::Find;
 
 sub cat(*@files) is export {
@@ -80,10 +83,8 @@ sub dos2unix($file) is export {
 }
 
 sub which($name) is export {
-    for $*SPEC.path.map({ $*SPEC.catfile($^dir, $name) }) {
-        return $_ if .IO.x;
-    }
-    Str
+  require File::Which <&which>;
+  which($name)
 }
 
 # vim: ft=perl6

--- a/t/02-shell-command.t
+++ b/t/02-shell-command.t
@@ -41,5 +41,9 @@ lives-ok { cp 't/dir1/file.foo', 't/dir2'; }, '#5';
 ok 't/dir2/file.foo'.IO.f, '#5';
 rm_rf 't/dir2';
 
-ok which('perl6').IO.x, 'which - perl6 is found';
+if $*DISTRO.is-win {
+  ok which('perl6'), 'which - perl6 is found';
+} else {
+  ok which('perl6').IO.x, 'which - perl6 is found';
+}
 nok which('scoodelyboopersnake'), 'which - missing exe is false';

--- a/t/02-shell-command.t
+++ b/t/02-shell-command.t
@@ -1,6 +1,11 @@
 use v6;
+
 use Test;
+
+use lib 'lib';
+
 use Shell::Command;
+
 plan 16;
 
 mkpath 't/dupa/foo/bar';


### PR DESCRIPTION
- Use File::Which for a true cross platform `which`. This will fix windows `which` test failures.
- use lib 'lib' in tests.
- Add a proper README.md.
- Add AppVeyor build support.
- Ignore precompiled files.