### PR TITLE
Mention already implemented commands missing from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,9 @@ use Shell::Command;
 # Recursive folder copy
 cp 't/dir1', 't/dir2', :r;
 
+# Remove a file
+rm_f 'to_delete';
+
 # Remove directory
 rmdir 't/dupa/foo/bar';
 
@@ -29,6 +32,9 @@ rm_rf 't/dir2';
 
 # Find perl6 in executable path
 my $perl6_path = which('perl6');
+
+# Concatenate the contents of a file or list of files
+cat "file1.txt", "file2.txt";
 ```
 ## See Also
 - [Shell::Command](https://metacpan.org/pod/Shell::Command)


### PR DESCRIPTION
There were only two commands missing from the README that had been
implemented but not yet mentioned in the examples section.  This commit adds
a quick example of both so that users can be more aware of the available
functions without having to search in perl5's Shell::Command, which itself
redirects to ExtUtils::Command for a list of the implemented commands.