### PR TITLE
fix panda/rakudo star installation on system with no previous perl6

### DIFF
--- a/t/02-shell-command.t
+++ b/t/02-shell-command.t
@@ -44,6 +44,6 @@ rm_rf 't/dir2';
 if $*DISTRO.is-win || ($*DISTRO.name eq 'macosx') {
   skip 'which is not working properly on Windows/Mac OS X. Please use File::Which', 2;
 } else {
-  ok which('ls).IO.x, 'which - ls is found';
+  ok which('ls').IO.x, 'which - ls is found';
   nok which('scoodelyboopersnake'), 'which - missing exe is false';
 }

--- a/t/02-shell-command.t
+++ b/t/02-shell-command.t
@@ -44,6 +44,6 @@ rm_rf 't/dir2';
 if $*DISTRO.is-win || ($*DISTRO.name eq 'macosx') {
   skip 'which is not working properly on Windows/Mac OS X. Please use File::Which', 2;
 } else {
-  ok which('perl6').IO.x, 'which - perl6 is found';
+  ok which('ls).IO.x, 'which - ls is found';
   nok which('scoodelyboopersnake'), 'which - missing exe is false';
 }


### PR DESCRIPTION
Test for presence of 'ls' rather than 'perl6' since Shell::Command may be used before perl6 is in the path.
This happens when panda in Rakudo Star is bootstrapped on a system without a previous perl6 install using the Shell::Command as embedded in panda.