### PR TITLE
Improve message for test fail if perl6 not on PATH

### DIFF
--- a/t/02-shell-command.t
+++ b/t/02-shell-command.t
@@ -44,6 +44,7 @@ rm_rf 't/dir2';
 if $*DISTRO.is-win || ($*DISTRO.name eq 'macosx') {
   skip 'which is not working properly on Windows/Mac OS X. Please use File::Which', 2;
 } else {
-  ok which('perl6').IO.x, 'which - perl6 is found';
+  my $perl6 = which('perl6');
+  ok $perl6.defined && $perl6.IO.x, 'which - perl6 is found on PATH';
   nok which('scoodelyboopersnake'), 'which - missing exe is false';
 }


### PR DESCRIPTION
In the unlikely event of not having `perl6` in the `PATH`, the tests failed with a bit of a cryptic message ("Cannot look up attributes in a type object in block <unit> at t/02-shell-command.t") - found whilst installing panda, and took > 5 seconds to figure out.

Simplest approach seemed to be just giving a message to that effect when that test fails, which is similar to what File::Which appears to do. Could get more complicated by having an +x file in the distro, temporarily adding it to path, but that seems like overkill.